### PR TITLE
Fix bug in the media property

### DIFF
--- a/gopro/GoPro.py
+++ b/gopro/GoPro.py
@@ -87,6 +87,7 @@ class GoPro(object):
         r = requests.get(self._media_url)
         expression = r'"(\w+.JPG)"'
         pattern = re.compile(expression)
+        self._media = []
         for item in re.findall(pattern, r.content):
             item_url = self._media_url + item
             self._media.append(Media(item_url))


### PR DESCRIPTION
Since the list of media files where always appended to the media field it grow-ed every time it was accessed. This fixes the bug by clearing the array before repopulating it.
